### PR TITLE
Added graphs (-g) option to output directed graph of state groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.data
 *.old
 out.sql
+*.csv

--- a/src/graphing.rs
+++ b/src/graphing.rs
@@ -5,26 +5,14 @@ use super::StateGroupEntry;
 
 type Graph = BTreeMap<i64, StateGroupEntry>;
 
-fn output_csv(groups: &Graph ,edges_output: &mut File, nodes_output: &mut File) {
-    writeln!(
-        edges_output,
-        "Source;Target",
-    )
-    .unwrap();
+fn output_csv(groups: &Graph, edges_output: &mut File, nodes_output: &mut File) {
+    writeln!(edges_output, "Source;Target",).unwrap();
 
-    writeln!(
-        nodes_output,
-        "Id;Rows;Root;Label",
-    ).unwrap();
+    writeln!(nodes_output, "Id;Rows;Root;Label",).unwrap();
 
-    for (source,entry) in groups {
+    for (source, entry) in groups {
         if let Some(target) = entry.prev_state_group {
-            writeln!(
-                edges_output,
-                "{};{}",
-                source,
-                target,
-            ).unwrap();
+            writeln!(edges_output, "{};{}", source, target,).unwrap();
         }
 
         writeln!(
@@ -34,7 +22,8 @@ fn output_csv(groups: &Graph ,edges_output: &mut File, nodes_output: &mut File) 
             entry.state_map.len(),
             entry.prev_state_group.is_none(),
             entry.state_map.len(),
-        ).unwrap();
+        )
+        .unwrap();
     }
 }
 
@@ -44,6 +33,6 @@ pub fn make_graphs(before: Graph, after: Graph) {
     let mut after_edges_file = File::create("after_edges.csv").unwrap();
     let mut after_nodes_file = File::create("after_nodes.csv").unwrap();
 
-    output_csv(&before,  &mut before_edges_file, &mut before_nodes_file);
+    output_csv(&before, &mut before_edges_file, &mut before_nodes_file);
     output_csv(&after, &mut after_edges_file, &mut after_nodes_file);
 }

--- a/src/graphing.rs
+++ b/src/graphing.rs
@@ -1,0 +1,49 @@
+use std::collections::BTreeMap;
+use std::{fs::File, io::Write};
+
+use super::StateGroupEntry;
+
+type Graph = BTreeMap<i64, StateGroupEntry>;
+
+fn output_csv(groups: &Graph ,edges_output: &mut File, nodes_output: &mut File) {
+    writeln!(
+        edges_output,
+        "Source;Target",
+    )
+    .unwrap();
+
+    writeln!(
+        nodes_output,
+        "Id;Rows;Root;Label",
+    ).unwrap();
+
+    for (source,entry) in groups {
+        if let Some(target) = entry.prev_state_group {
+            writeln!(
+                edges_output,
+                "{};{}",
+                source,
+                target,
+            ).unwrap();
+        }
+
+        writeln!(
+            nodes_output,
+            "{};{};{};\"{}\"",
+            source,
+            entry.state_map.len(),
+            entry.prev_state_group.is_none(),
+            entry.state_map.len(),
+        ).unwrap();
+    }
+}
+
+pub fn make_graphs(before: Graph, after: Graph) {
+    let mut before_edges_file = File::create("before_edges.csv").unwrap();
+    let mut before_nodes_file = File::create("before_nodes.csv").unwrap();
+    let mut after_edges_file = File::create("after_edges.csv").unwrap();
+    let mut after_nodes_file = File::create("after_nodes.csv").unwrap();
+
+    output_csv(&before,  &mut before_edges_file, &mut before_nodes_file);
+    output_csv(&after, &mut after_edges_file, &mut after_nodes_file);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct Config {
     min_saved_rows: Option<i32>,
     transactions: bool,
     level_sizes: LevelSizes,
-    graphs: bool
+    graphs: bool,
 }
 
 impl Config {
@@ -513,7 +513,7 @@ impl Config {
     min_saved_rows = "String::from(\"\")",
     transactions = false,
     level_sizes = "String::from(\"100,50,25\")",
-    graphs = false,
+    graphs = false
 )]
 fn run_compression(
     db_url: String,


### PR DESCRIPTION
It outputs nodes and edges information before and after the
compressor has run - these can be visualised in a tool like Gephi

A good way to visualise what the compressor is actually doing!